### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add configuration for dependabot to automatically create pull-requests for GitHub Actions updates

Might need to go into the repository's settings page to enable dependabot if the presence of this file does not enable it automatically.