### PR TITLE
Update Hugo version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.120.2
+      HUGO_VERSION: '0.149.1'
     steps:
       - name: Install Hugo CLI
         run: |

--- a/themes/ubuntukr/layouts/partials/head.html
+++ b/themes/ubuntukr/layouts/partials/head.html
@@ -7,13 +7,29 @@
     <link rel="icon" type="image/png" sizes="16x16" href='{{ "/img/favicon/favicon-16x16.png" | relURL }}'>
 
 
-    {{- $options := (dict "includePaths" (slice "node_modules") "transpiler" "dartsass") -}}
-    {{ $style := resources.Get "sass/theme.scss" | resources.ToCSS $options | resources.Minify | resources.Fingerprint }}
     <title>{{ .Title }} | {{ .Site.Title }}</title>
     <!--  Open Graph Protocol -->
     <meta property="og:site_name" content="{{ .Site.Title }}" />
     <meta property="og:title" content="{{ .Title }}" />
 
     <!--   SASS Stylesheets -->
-    <link rel="stylesheet" href="{{ $style.Permalink }}">
+    {{ with resources.Get "sass/theme.scss" }}
+        {{ $opts := dict
+            "enableSourceMap" hugo.IsDevelopment
+            "outputStyle" (cond hugo.IsDevelopment "expanded" "compressed")
+            "targetPath" "css/main.css"
+            "transpiler" "dartsass"
+            "vars" site.Params.styles
+            "includePaths" (slice "node_modules")
+        }}
+        {{ with . | toCSS $opts }}
+            {{ if hugo.IsDevelopment }}
+                <link rel="stylesheet" href="{{ .RelPermalink }}">
+            {{ else }}
+                {{ with . | fingerprint }}
+                    <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+                {{ end }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
 </head>


### PR DESCRIPTION
Bump version of Hugo used for deploying to GitHub Pages to latest as of this commit (v0.149.1)

Replace usage of Resources.ToCSS, which has been removed from Hugo, with css.Sass (ref: https://gohugo.io/functions/resources/tocss/ and https://gohugo.io/functions/css/sass/)